### PR TITLE
ignore /core/target and /agent/target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 /core/core.iml
 /agent/agent.iml
 /target
+/core/target
+/agent/target
 /.settings
 /.classpath
 /.project


### PR DESCRIPTION
目前的配置只能忽略掉根目录下的target目录，core和agent下的target会纳入版本控制。