### PR TITLE
Fix greys-pacakages.sh relative dir issue

### DIFF
--- a/bin/greys-packages.sh
+++ b/bin/greys-packages.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
+BASEDIR="$( cd "$( dirname "$0" )" && pwd )"
+
 # greys's target dir
-GREYS_TARGET_DIR=../target/greys
+GREYS_TARGET_DIR=${BASEDIR}/../target/greys
 
 # greys's version
-GREYS_VERSION=$(cat ..//core/src/main/resources/com/github/ompc/greys/core/res/version)
+GREYS_VERSION=$(cat ${BASEDIR}/..//core/src/main/resources/com/github/ompc/greys/core/res/version)
 
 # define newset greys lib home
 NEWEST_GREYS_LIB_HOME=${HOME}/.greys/lib/${GREYS_VERSION}/greys
@@ -20,29 +22,29 @@ exit_on_err()
 }
 
 # maven package the greys
-mvn clean package -Dmaven.test.skip=true -f ../pom.xml \
+mvn clean package -Dmaven.test.skip=true -f ${BASEDIR}/../pom.xml \
 || exit_on_err 1 "package greys failed."
 
 # reset the target dir
 mkdir -p ${GREYS_TARGET_DIR}
 
 # copy jar to TARGET_DIR
-cp ../core/target/greys-core-jar-with-dependencies.jar ${GREYS_TARGET_DIR}/greys-core.jar
-cp ../agent/target/greys-agent-jar-with-dependencies.jar ${GREYS_TARGET_DIR}/greys-agent.jar
+cp ${BASEDIR}/../core/target/greys-core-jar-with-dependencies.jar ${GREYS_TARGET_DIR}/greys-core.jar
+cp ${BASEDIR}/../agent/target/greys-agent-jar-with-dependencies.jar ${GREYS_TARGET_DIR}/greys-agent.jar
 
 # copy shell to TARGET_DIR
-cat install-local.sh|sed "s/GREYS_VERSION=0.0.0.0/GREYS_VERSION=${GREYS_VERSION}/g" > ${GREYS_TARGET_DIR}/install-local.sh
+cat ${BASEDIR}/install-local.sh|sed "s/GREYS_VERSION=0.0.0.0/GREYS_VERSION=${GREYS_VERSION}/g" > ${GREYS_TARGET_DIR}/install-local.sh
 #chmod +x ${GREYS_TARGET_DIR}/install-local.sh
-cp greys.sh ${GREYS_TARGET_DIR}/greys.sh
-cp ga.sh ${GREYS_TARGET_DIR}/ga.sh
-cp gs.sh ${GREYS_TARGET_DIR}/gs.sh
+cp ${BASEDIR}/greys.sh ${GREYS_TARGET_DIR}/greys.sh
+cp ${BASEDIR}/ga.sh ${GREYS_TARGET_DIR}/ga.sh
+cp ${BASEDIR}/gs.sh ${GREYS_TARGET_DIR}/gs.sh
 chmod +x ${GREYS_TARGET_DIR}/*.sh
 
 # zip the greys
-cd ../target/
+cd ${BASEDIR}/../target/
 zip -r greys-${GREYS_VERSION}-bin.zip greys/
 cd -
 
 # install to local
 mkdir -p ${NEWEST_GREYS_LIB_HOME}
-cp ../target/greys/* ${NEWEST_GREYS_LIB_HOME}/
+cp ${BASEDIR}/../target/greys/* ${NEWEST_GREYS_LIB_HOME}/


### PR DESCRIPTION
greys-pacakages.sh only looks for the relative path when pacakage
artifact, which will cause problem when calling the script from
other dir. For example, from project root dir.

Add absolute path to resolve this issue.