### PR TITLE
Fix issue that some commands can't run in JDK9 env

### DIFF
--- a/core/src/main/java/com/github/ompc/greys/core/advisor/Enhancer.java
+++ b/core/src/main/java/com/github/ompc/greys/core/advisor/Enhancer.java
@@ -126,7 +126,7 @@ public class Enhancer implements ClassFileTransformer {
         // 看来间谍不存在啊
         catch (ClassNotFoundException cnfe) {
 
-            try {// 在目标类加载起中混入间谍
+            try {// 在目标类加载器中混入间谍
                 spyClassFromTargetClassLoader = defineClass(
                         targetClassLoader,
                         spyClassName,

--- a/core/src/main/java/com/github/ompc/greys/core/command/JvmCommand.java
+++ b/core/src/main/java/com/github/ompc/greys/core/command/JvmCommand.java
@@ -115,7 +115,10 @@ public class JvmCommand implements Command {
                 .add("VM-VERSION", runtimeMXBean.getVmVersion())
                 .add("INPUT-ARGUMENTS", toCol(runtimeMXBean.getInputArguments()))
                 .add("CLASS-PATH", runtimeMXBean.getClassPath())
-                .add("BOOT-CLASS-PATH", runtimeMXBean.getBootClassPath())
+                .add("BOOT-CLASS-PATH", runtimeMXBean.isBootClassPathSupported() ?
+                        runtimeMXBean.getBootClassPath() :
+                        "This JVM does not support boot class path.")
+                //TODO: add "MODULE-PATH" for JDK 9
                 .add("LIBRARY-PATH", runtimeMXBean.getLibraryPath());
 
         return view.rendering();

--- a/core/src/main/java/com/github/ompc/greys/core/util/matcher/ReflectMatcher.java
+++ b/core/src/main/java/com/github/ompc/greys/core/util/matcher/ReflectMatcher.java
@@ -38,29 +38,11 @@ public abstract class ReflectMatcher<T> implements Matcher<T> {
 
     @Override
     final public boolean matching(T target) {
-
-        // 推空保护
-        if (null == target) {
-            return false;
-        }
-
-        // 匹配mod
-        if (!matchingModifier(getTargetModifiers(target))) {
-            return false;
-        }
-
-        // 匹配名称
-        if (!matchingName(getTargetName(target))) {
-            return false;
-        }
-
-        // 匹配Annotation
-        if (!matchingAnnotation(getTargetAnnotationArray(target))) {
-            return false;
-        }
-
-        // 执行目标实现类的比对
-        return reflectMatching(target);
+        return (null != target && // 推空保护
+                matchingModifier(getTargetModifiers(target)) && // 匹配mod
+                matchingName(getTargetName(target)) && // 匹配名称
+                matchingAnnotation(getTargetAnnotationArray(target)) && // 匹配Annotation
+                reflectMatching(target)); // 执行目标实现类的比对
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -71,12 +71,12 @@
             <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm</artifactId>
-                <version>5.0.3</version>
+                <version>6.0</version>
             </dependency>
             <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm-commons</artifactId>
-                <version>5.0.3</version>
+                <version>6.0</version>
                 <!--<exclusions>-->
                 <!--<exclusion>-->
                 <!--<groupId>org.ow2.asm</groupId>-->
@@ -87,7 +87,7 @@
             <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm-util</artifactId>
-                <version>5.0.3</version>
+                <version>6.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
1. ASM 5.0.3 does not support for JDK9, any class compiled with major
version greater than 52 will fail ClassReader initialization. Therefore,
change deps to ASM 6.0, which has the JDK9 support.

2. JDK9 remove the BootClass Support,
https://bugs.openjdk.java.net/browse/JDK-8073727
It means that java.lang.management.RuntimeMXBean#getBootClassPath will
always return UOE.

3. Some minor change in the code

TODO: add "MODULE-PATH" for JDK 9 env.