### PR TITLE
解决HOME为/或者不以/结尾时，报ClassNotFoundException错误的问题

### DIFF
--- a/bin/greys.sh
+++ b/bin/greys.sh
@@ -7,7 +7,9 @@
 # version : 1.7.6.6
 
 # define greys's home
-GREYS_HOME=${HOME}/.greys
+[[ "${HOME}" == */ ]] \
+  && GREYS_HOME=${HOME}.greys \
+  || GREYS_HOME=${HOME}/.greys
 
 # define greys's lib
 GREYS_LIB_DIR=${GREYS_HOME}/lib


### PR DESCRIPTION
当HOME为根目录"/"时，GREYS_HOME变量将赋值为"//.greys"
导致AgentClassLoader在加载com.github.ompc.greys.core.*时，由于jar包路径的问题，抛出ClassNotFoundException异常